### PR TITLE
Added support for skipped UV coordinates

### DIFF
--- a/obj.go
+++ b/obj.go
@@ -455,7 +455,7 @@ func pushIndex(currGroup *Group, o *Obj, i int) {
 }
 
 func addVertex(p *objParser, o *Obj, index string, options *ObjParserOptions) error {
-	ind := splitSlash(index)
+	ind := splitSlash(strings.Replace(index, "//", "/0/", 1))
 	size := len(ind)
 	if size < 1 || size > 3 {
 		return fmt.Errorf("addVertex: line=%d bad index=[%s] size=%d", p.lineCount, index, size)
@@ -469,7 +469,8 @@ func addVertex(p *objParser, o *Obj, index string, options *ObjParserOptions) er
 
 	var ti int
 	var tIndex string
-	if size > 1 {
+	hasTextureCoord := strings.Index(index, "//") == -1 && size > 1
+	if hasTextureCoord {
 		t, e := strconv.ParseInt(ind[1], 10, 32)
 		if e != nil {
 			return fmt.Errorf("addVertex: line=%d bad integer 2nd index=[%s]: %v", p.lineCount, ind[1], e)
@@ -506,7 +507,7 @@ func addVertex(p *objParser, o *Obj, index string, options *ObjParserOptions) er
 	o.Coord = append(o.Coord, p.vertCoord[vOffset+1]) // y
 	o.Coord = append(o.Coord, p.vertCoord[vOffset+2]) // z
 
-	if tIndex != "" {
+	if tIndex != "" && hasTextureCoord {
 		tOffset := ti * 2
 		//fmt.Printf("ti=%d tOffset=%d textCoord=%v len=%d\n", ti, tOffset, p.textCoord, len(p.textCoord))
 

--- a/obj.go
+++ b/obj.go
@@ -498,6 +498,10 @@ func addVertex(p *objParser, o *Obj, index string, options *ObjParserOptions) er
 	}
 
 	vOffset := vi * 3
+	if vOffset+2 >= len(p.vertCoord) {
+		return fmt.Errorf("err: line=%d invalid vertex index=[%s]", p.lineCount, ind[0])
+	}
+
 	o.Coord = append(o.Coord, p.vertCoord[vOffset+0]) // x
 	o.Coord = append(o.Coord, p.vertCoord[vOffset+1]) // y
 	o.Coord = append(o.Coord, p.vertCoord[vOffset+2]) // z
@@ -505,6 +509,11 @@ func addVertex(p *objParser, o *Obj, index string, options *ObjParserOptions) er
 	if tIndex != "" {
 		tOffset := ti * 2
 		//fmt.Printf("ti=%d tOffset=%d textCoord=%v len=%d\n", ti, tOffset, p.textCoord, len(p.textCoord))
+
+		if tOffset+1 >= len(p.textCoord) {
+			return fmt.Errorf("err: line=%d invalid texture index=[%s]", p.lineCount, ind[1])
+		}
+
 		o.Coord = append(o.Coord, p.textCoord[tOffset+0]) // u
 		o.Coord = append(o.Coord, p.textCoord[tOffset+1]) // v
 		o.TextCoordFound = true


### PR DESCRIPTION
Hi !

GWOB does not support a tri description like this one.
f 1//1 2//2 3//3
Here is a PR to add this feature.