### PR TITLE
Fix smooth group bug causing new empty group

### DIFF
--- a/obj.go
+++ b/obj.go
@@ -868,6 +868,10 @@ func parseLine(p *objParser, o *Obj, line string, options *ObjParserOptions) (bo
 		smooth := line[2:]
 		if s, err := smoothGroup(smooth); err == nil {
 			if p.currGroup.Smooth != s {
+				if p.currGroup.IndexCount == 0 {
+					// mark previous empty group as bogus
+					p.currGroup.IndexCount = -1
+				}
 				// create new group
 				p.currGroup = o.newGroup(p.currGroup.Name, p.currGroup.Usemtl, len(o.Indices), s)
 			}


### PR DESCRIPTION
This PR aims to fix the following detected bug:

## Description of the bug
When reading an obj file containing a line defining a group as smooth (e.g. `s 1`), if this happens while the current group has an IndexCount of 0, a new group is created and the old one is not marked for deletion, originating an empty group to be left in the output.

### Screenshots
![image](https://github.com/udhos/gwob/assets/10686508/2eb448ec-668f-4b8d-8a1a-e3f6e2ba4d4a)

### How to Reproduce
Use the following obj file and observe the output.
```
o Cube.001
v 1 -1 1
v -1 -1 1
v 1 1 1
v -1 1 1
v 1 -1 -1
v 1 1 -1
v -1 1 -1
v -1 -1 -1
vt 0 0
vt 1 0
vt 0 1
vt 1 1
vt 1 0
vt 1 1
vt 0 1
vt 0 0
vn 0 -1 0
vn 0 1 0
vn 1 0 0
vn -1 0 0
vn 0 0 -1
vn 0 0 1
s 1
f 1/1/6 3/3/6 4/4/6
f 1/1/6 4/4/6 2/2/6
f 1/1/1 2/2/1 8/8/1
f 1/1/1 8/8/1 5/5/1
f 1/1/3 5/5/3 6/6/3
f 1/1/3 6/6/3 3/3/3
```

## Expected behavior
The output should not contain an empty group.